### PR TITLE
Static typing: Basic types

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,5 +1,6 @@
 import           System.Environment (getArgs, withArgs)
 import           System.Exit        (exitFailure, exitSuccess)
+import           System.IO          (hFlush, stdout)
 
 import qualified Baalbolge.Skel     (Result)
 import qualified TypeChecker        (checkTypes)
@@ -10,10 +11,10 @@ import           Baalbolge.Abs      (Exps)
 import           Baalbolge.Lex      (Token, mkPosToken)
 import           Baalbolge.Par      (myLexer, pExps)
 import           Baalbolge.Print    (Print)
+import           Types
 import           Util               (Command (..))
 
 
-type Err        = Either String
 type ParseFun a = [Token] -> Err a
 type Result     = Exps
 
@@ -28,6 +29,8 @@ interactiveMode = readStdIn "" 0 >> interactiveMode
 
 readStdIn :: String -> Int -> IO ()
 readStdIn line c = do
+    putStr ">> "
+    hFlush stdout
     currentLine <- getLine
     case Util.readCommand currentLine of
       Exit  -> exitSuccess

--- a/src/TypeChecker.hs
+++ b/src/TypeChecker.hs
@@ -3,10 +3,63 @@ module TypeChecker
       checkTypes
   ) where
 
-import qualified Baalbolge.Abs (Exps)
+import           Control.Monad (foldM)
 
-type Err = Either String
+import qualified Baalbolge.Abs as BG
 
--- checkTypes
-checkTypes :: Baalbolge.Abs.Exps -> Err Baalbolge.Abs.Exps
-checkTypes = undefined
+import           Types
+
+{- | Checks the types in the given program. The check is pefrormed in a static manner.
+If some of the types are unknown due to usage of `var` type, the check is a success and
+any problems with types are found and thrown during execution of the program.
+
+For the whole program, any type can be returned.
+-}
+checkTypes :: BG.Exps -> Err BG.Exps
+checkTypes prog@(BG.Program _ exps) = do
+    _ <- checkTypesExps exps
+    return prog
+
+{- | A function, which checks the return type of the list of Exps. The check is run for
+each element of the list of Exps.
+
+For the list of Exps, any type can be returned.
+-}
+checkTypesExps :: [BG.Exp] -> Err Type
+checkTypesExps = foldM expsMapper TUnit
+
+{- | A function, which maps Exps from the list and determines the return type of the whole
+list. In Baalbolge, the first Exp to return a type other than Unit determines the return
+Type of the whole list of Exps.
+-}
+expsMapper :: Type -> BG.Exp -> Err Type
+expsMapper TUnit e =
+    case checkTypesExp e of
+        Left err -> Left err
+        Right t  -> Right t
+expsMapper t e =
+    case checkTypesExp e of
+        Left err -> Left err
+        _        -> Right t
+
+{- | A function, which determines the return type of a single Exp.
+
+$setup
+>>> let p = Just (2,2)
+>>> let b = (BG.BTrue p)
+
+>>> checkTypesExp (BG.EUnit p)
+Right TUnit
+
+>>> checkTypesExp (BG.EInt p 42)
+Right TInt
+
+>>> checkTypesExp (BG.EBool p b)
+Right TBool
+-}
+checkTypesExp :: BG.Exp -> Err Type
+checkTypesExp (BG.EUnit _) = return TUnit
+checkTypesExp (BG.EInt _ _) = return TInt
+checkTypesExp (BG.EBool _ _) = return TBool
+
+checkTypesExp e = Left $ "Checking types of exp: " ++ show e ++ " is not yet implemented"

--- a/src/TypeChecker.hs
+++ b/src/TypeChecker.hs
@@ -1,0 +1,12 @@
+module TypeChecker
+    ( -- * Functions
+      checkTypes
+  ) where
+
+import qualified Baalbolge.Abs (Exps)
+
+type Err = Either String
+
+-- checkTypes
+checkTypes :: Baalbolge.Abs.Exps -> Err Baalbolge.Abs.Exps
+checkTypes = undefined

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1,0 +1,12 @@
+module Types
+    ( -- * Data types
+      Err
+      
+      -- * Data structures
+      , Type (..)
+  ) where
+
+type Err = Either String
+
+-- | The representation of types used in Baalbolge
+data Type = TUnit | TInt | TBool | TVar deriving (Show)


### PR DESCRIPTION
Implementation of static typing for basic types as a part of bigger #15.

Currently, the typing is implemented for 
* `int`
* `bool`
* unit

Resolves #23 