### PR TITLE
[#65] Interpreter: function as an argument

### DIFF
--- a/src/Interpreter/Types.hs
+++ b/src/Interpreter/Types.hs
@@ -17,12 +17,28 @@ module Interpreter.Types
 import qualified Data.Map             as M
 
 import           Control.Monad.Except
-import           Control.Monad.Reader
+import Control.Monad.Reader ( Reader )
 import           Control.Monad.State
 
 import qualified Baalbolge.Abs        as BG
 
-import           Types
+
+{- | The representation of types used in Baalbolge for the purpose of computing the result
+of computation.
+-}
+data Result = RUnit
+    | RInt Integer
+    | RBool Bool
+    | RFunc BG.Type [Arg] [BG.Exp] InterpreterMemory
+    | RBFunc BuiltInFunction
+
+instance Show Result
+  where
+    show RUnit = "unit"
+    show (RInt i) = "int " ++ show i
+    show (RBool b) = "bool " ++ show b
+    show RFunc {} = "func"
+    show RBFunc {} = "built-in"
 
 type ExT = ExceptT String
 
@@ -37,4 +53,6 @@ type InterpreterMemoryState = ExT (State InterpreterMemory) InterpreterMemory
 type BuiltInFunction = [BG.Exp] -> InterpreterState
 data Arg = Arg BG.Type Name
 
-data MemoryObj = Var Result | BuiltIn BuiltInFunction | Func BG.Type [Arg] [BG.Exp]
+data MemoryObj = Var Result
+    | BuiltIn BuiltInFunction
+    | Func BG.Type [Arg] [BG.Exp] InterpreterMemory

--- a/src/Interpreter/Util.hs
+++ b/src/Interpreter/Util.hs
@@ -69,6 +69,8 @@ pprintResult :: Result -> String
 pprintResult RUnit     = "unit"
 pprintResult (RInt _)  = "int"
 pprintResult (RBool _) = "bool"
+pprintResult RFunc {} = "func"
+pprintResult RBFunc {} = "built-in"
 
 {- | A function used for Data.Map.unionWith, which preferes the second object over the
 first one

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -8,7 +8,8 @@ import qualified Util               (checkParentheses, exit, notImplemented,
                                      readCommand)
 
 import           Baalbolge.Par      (myLexer, pExps)
-import           Types
+import           Interpreter.Types  (Result)
+import           Types              (Err)
 import           Util               (Command (..), printResponse)
 
 
@@ -18,12 +19,8 @@ fileMode f = putStrLn f >> readFile f >>= runFile
 runFile :: String -> IO ()
 runFile s =
     case run s of
-      Left err -> do
-        putStrLn err
-        exitFailure
-      Right res -> do
-        Util.printResponse res
-        Util.exit res
+        Left err  -> putStrLn err >> exitFailure
+        Right res -> Util.printResponse res >> Util.exit res
 
 interactiveMode :: IO ()
 interactiveMode = readStdIn "" 0 >> interactiveMode

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1,15 +1,8 @@
 module Types
     ( -- * Data types
       Err
-
-      -- * Data structures
-      , Result (..)
   ) where
 
 
 type Err = Either String
 
-{- | The representation of types used in Baalbolge for the purpose of computing the result
-of computation.
--}
-data Result = RUnit | RInt Integer | RBool Bool deriving (Show)

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -14,11 +14,11 @@ module Util
       , notImplementedError
   ) where
 
-import           System.Exit     (ExitCode (ExitFailure), exitFailure,
-                                  exitSuccess, exitWith)
+import           System.Exit       (ExitCode (ExitFailure), exitFailure,
+                                    exitSuccess, exitWith)
 
-import           Baalbolge.Print (Print, printTree)
-import           Types
+import           Baalbolge.Print   (Print, printTree)
+import           Interpreter.Types
 
 
 -- | A command for controlling the interpeter in the interactive mode.
@@ -84,6 +84,8 @@ printResponse :: Result -> IO ()
 printResponse RUnit     = putStrLn ""
 printResponse (RBool b) = print b
 printResponse (RInt v)  = print v
+printResponse RFunc {} = putStrLn "I'm a teapot"
+printResponse RBFunc {} = putStrLn "I'm a teapot"
 
 exit :: Result -> IO ()
 exit RUnit = exitSuccess
@@ -95,6 +97,8 @@ exit (RInt v)
     | otherwise = exitWith $ ExitFailure (fromIntegral retVal)
   where
     retVal = v `mod` 256
+exit RFunc {} = exitWith $ ExitFailure 13
+exit RBFunc {} = exitWith $ ExitFailure 13
 
 notImplemented :: IO()
 notImplemented = putStrLn "Not yet implemented..."


### PR DESCRIPTION
Added passing function as an argument to the interpreter. At the same time, the function saves the current state of the memory, so that it can use variables available at the moment of creation of the function. It's a part of a bigger #21 

Resolves #65 