### PR TITLE
[#81] Fixed returning function in runtime

### DIFF
--- a/src/Interpreter.hs
+++ b/src/Interpreter.hs
@@ -21,7 +21,12 @@ import           Types
 {- | Interprets the whole program and returns its result or an error.
 -}
 interpret :: BG.Exps -> Err Result
-interpret (BG.Program _ exps) = runReader (runExceptT $ interpretExps exps) initialInterpreterMem
+interpret (BG.Program _ exps) = do
+    ret <- runReader (runExceptT $ interpretExps exps) initialInterpreterMem
+    case ret of
+        RFunc {} -> throwError "Runtime exception! The program cannot return a function!"
+        RBFunc _ -> throwError "Runtime exception! The program cannot return a function!"
+        _ -> return ret
 
 
 


### PR DESCRIPTION
Before returning a result from the Interpreter part of the program, the value is checked. If it's a function, an error is thrown.

Resolves #81 