### PR TITLE
[#90] Added print as a grammar feature

### DIFF
--- a/src/baalbolge.cf
+++ b/src/baalbolge.cf
@@ -21,6 +21,7 @@ IIf.       InternalFunc ::= "if" Exp Exp Exp ;
 IWhile.    InternalFunc ::= "while" Exp Exp ;
 IWhen.     InternalFunc ::= "when" Exp Exp ;
 IConc.     InternalFunc ::= ";" [SameState] ;
+IPrint.    InternalFunc ::= "print" [Exp] ;
 
 SState. SameState ::= Exp ;
 


### PR DESCRIPTION
Added the `print` function as a part of the grammar.

Resolves #90 